### PR TITLE
Add startup script for docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ Edit the various Dockerfile or override the corresponding arg variable to match 
 ## Run 
 
 > docker-compose up 
+
+
+## Test oaisim
+```
+sudo -E ./run_enb_ue_virt_s1 
+ping google.com -I oip1 
+```
+
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Edit the various Dockerfile or override the corresponding arg variable to match 
 
 ## Test oaisim
 ```
-sudo -E ./run_enb_ue_virt_s1 
+sudo -E ./run_enb_ue_virt_s1 --config-file ~/docker-openairinterface-epc/oaisim/enb.band7.generic.oaisim.local_mme.conf
 ping google.com -I oip1 
 ```
 

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -18,20 +18,20 @@ ENV MYSQL_ROOT_PASSWORD=linux
 
 #RUN apt-get update && apt-get -qy install curl
 #RUN curl https://gitlab.eurecom.fr/oai/openair-cn/raw/develop/src/oai_hss/db/oai_db.sql -o  /docker-entrypoint-initdb.d/oai_db.sql
-ADD oai_db.sql  /docker-entrypoint-initdb.d/oai_db.sql
+# ADD oai_db.sql  /docker-entrypoint-initdb.d/oai_db.sql
 
 
 # Customize the SQL based on the arguments passed on build time
 
 # MME settings
-RUN sed -i s/'mme.openair4G.eur'/$MME/g /docker-entrypoint-initdb.d/oai_db.sql
-RUN sed -i s/'openair4G.eur'/$REALM/g /docker-entrypoint-initdb.d/oai_db.sql
+# RUN sed -i s/'mme.openair4G.eur'/$MME/g /docker-entrypoint-initdb.d/oai_db.sql
+# RUN sed -i s/'openair4G.eur'/$REALM/g /docker-entrypoint-initdb.d/oai_db.sql
 
 # SIM card record
-RUN sed -i s/'oai.ipv4'/$APN/g /docker-entrypoint-initdb.d/oai_db.sql
+# RUN sed -i s/'oai.ipv4'/$APN/g /docker-entrypoint-initdb.d/oai_db.sql
 
-RUN sed -i s/208920100001100/$IMSI/g /docker-entrypoint-initdb.d/oai_db.sql
-RUN sed -i s/33638020000/$MSISDN/g /docker-entrypoint-initdb.d/oai_db.sql
-RUN sed -i s/0x8baf473f2f8fd09487cccbd7097c6862/$KI/g /docker-entrypoint-initdb.d/oai_db.sql
-RUN sed -i s/0xe734f8734007d6c5ce7a0508809e7e9c/$OPC/g  /docker-entrypoint-initdb.d/oai_db.sql
+# RUN sed -i s/208920100001100/$IMSI/g /docker-entrypoint-initdb.d/oai_db.sql
+# RUN sed -i s/33638020000/$MSISDN/g /docker-entrypoint-initdb.d/oai_db.sql
+# RUN sed -i s/0x8baf473f2f8fd09487cccbd7097c6862/$KI/g /docker-entrypoint-initdb.d/oai_db.sql
+# RUN sed -i s/0xe734f8734007d6c5ce7a0508809e7e9c/$OPC/g  /docker-entrypoint-initdb.d/oai_db.sql
 

--- a/db/oai_db.sql
+++ b/db/oai_db.sql
@@ -1,212 +1,232 @@
-CREATE DATABASE oai_db;
-
-USE oai_db;
-
-
--- MySQL dump 10.13  Distrib 5.5.46, for debian-linux-gnu (x86_64)
+-- phpMyAdmin SQL Dump
+-- version 4.8.0.1
+-- https://www.phpmyadmin.net/
 --
--- Host: localhost    Database: oai_db
--- ------------------------------------------------------
--- Server version	5.5.46-0ubuntu0.14.04.2
+-- Host: db
+-- Generation Time: Jun 23, 2018 at 01:09 PM
+-- Server version: 5.6.40
+-- PHP Version: 7.2.4
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+SET AUTOCOMMIT = 0;
+START TRANSACTION;
+SET time_zone = "+00:00";
+
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
-/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
-/*!40103 SET TIME_ZONE='+00:00' */;
-/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Database: `oai_db`
+--
+CREATE DATABASE oai_db;
+USE oai_db;
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `apn`
 --
 
-DROP TABLE IF EXISTS `apn`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `apn` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL,
   `apn-name` varchar(60) NOT NULL,
-  `pdn-type` enum('IPv4','IPv6','IPv4v6','IPv4_or_IPv6') NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `apn-name` (`apn-name`)
+  `pdn-type` enum('IPv4','IPv6','IPv4v6','IPv4_or_IPv6') NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
---
--- Dumping data for table `apn`
---
-
-LOCK TABLES `apn` WRITE;
-/*!40000 ALTER TABLE `apn` DISABLE KEYS */;
-/*!40000 ALTER TABLE `apn` ENABLE KEYS */;
-UNLOCK TABLES;
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `mmeidentity`
 --
 
-DROP TABLE IF EXISTS `mmeidentity`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `mmeidentity` (
-  `idmmeidentity` int(11) NOT NULL AUTO_INCREMENT,
+  `idmmeidentity` int(11) NOT NULL,
   `mmehost` varchar(255) DEFAULT NULL,
   `mmerealm` varchar(200) DEFAULT NULL,
-  `UE-Reachability` tinyint(1) NOT NULL COMMENT 'Indicates whether the MME supports UE Reachability Notifcation',
-  PRIMARY KEY (`idmmeidentity`)
-) ENGINE=MyISAM AUTO_INCREMENT=46 DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
+  `UE-Reachability` tinyint(1) NOT NULL COMMENT 'Indicates whether the MME supports UE Reachability Notifcation'
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 --
 -- Dumping data for table `mmeidentity`
 --
 
-LOCK TABLES `mmeidentity` WRITE;
-/*!40000 ALTER TABLE `mmeidentity` DISABLE KEYS */;
-INSERT INTO `mmeidentity` VALUES (1,'mme.openair4G.eur','openair4G.eur',0);
-/*!40000 ALTER TABLE `mmeidentity` ENABLE KEYS */;
-UNLOCK TABLES;
+INSERT INTO `mmeidentity` (`idmmeidentity`, `mmehost`, `mmerealm`, `UE-Reachability`) VALUES
+(1, 'mme.openair4G.eur', 'openair4G.eur', 0),
+(46, 'mme.openair4G.eur.openair4G.eur', 'openair4G.eur', 0);
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `pdn`
 --
 
-DROP TABLE IF EXISTS `pdn`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `pdn` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL,
   `apn` varchar(60) NOT NULL,
   `pdn_type` enum('IPv4','IPv6','IPv4v6','IPv4_or_IPv6') NOT NULL DEFAULT 'IPv4',
   `pdn_ipv4` varchar(15) DEFAULT '0.0.0.0',
   `pdn_ipv6` varchar(45) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT '0:0:0:0:0:0:0:0',
-  `aggregate_ambr_ul` int(10) unsigned DEFAULT '50000000',
-  `aggregate_ambr_dl` int(10) unsigned DEFAULT '100000000',
+  `aggregate_ambr_ul` int(10) UNSIGNED DEFAULT '50000000',
+  `aggregate_ambr_dl` int(10) UNSIGNED DEFAULT '100000000',
   `pgw_id` int(11) NOT NULL,
   `users_imsi` varchar(15) NOT NULL,
-  `qci` tinyint(3) unsigned NOT NULL DEFAULT '9',
-  `priority_level` tinyint(3) unsigned NOT NULL DEFAULT '15',
+  `qci` tinyint(3) UNSIGNED NOT NULL DEFAULT '9',
+  `priority_level` tinyint(3) UNSIGNED NOT NULL DEFAULT '15',
   `pre_emp_cap` enum('ENABLED','DISABLED') DEFAULT 'DISABLED',
   `pre_emp_vul` enum('ENABLED','DISABLED') DEFAULT 'DISABLED',
-  `LIPA-Permissions` enum('LIPA-prohibited','LIPA-only','LIPA-conditional') NOT NULL DEFAULT 'LIPA-only',
-  PRIMARY KEY (`id`,`pgw_id`,`users_imsi`),
-  KEY `fk_pdn_pgw1_idx` (`pgw_id`),
-  KEY `fk_pdn_users1_idx` (`users_imsi`)
-) ENGINE=MyISAM AUTO_INCREMENT=60 DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
+  `LIPA-Permissions` enum('LIPA-prohibited','LIPA-only','LIPA-conditional') NOT NULL DEFAULT 'LIPA-only'
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 --
 -- Dumping data for table `pdn`
 --
 
-LOCK TABLES `pdn` WRITE;
-/*!40000 ALTER TABLE `pdn` DISABLE KEYS */;
-INSERT INTO `pdn` VALUES (1,'oai.ipv4','IPv4','0.0.0.0','0:0:0:0:0:0:0:0',50000000,100000000,1,'208920100001100',9,15,'DISABLED','ENABLED','LIPA-only');
-/*!40000 ALTER TABLE `pdn` ENABLE KEYS */;
-UNLOCK TABLES;
+INSERT INTO `pdn` (`id`, `apn`, `pdn_type`, `pdn_ipv4`, `pdn_ipv6`, `aggregate_ambr_ul`, `aggregate_ambr_dl`, `pgw_id`, `users_imsi`, `qci`, `priority_level`, `pre_emp_cap`, `pre_emp_vul`, `LIPA-Permissions`) VALUES
+(1, 'internet', 'IPv4', '0.0.0.0', '0:0:0:0:0:0:0:0', 50000000, 100000000, 1, '901550000000000', 9, 15, 'DISABLED', 'ENABLED', 'LIPA-only'),
+(60, 'internet', 'IPv4', '0.0.0.0', '0:0:0:0:0:0:0:0', 50000000, 100000000, 1, '208930100001111', 9, 15, 'DISABLED', 'ENABLED', 'LIPA-only');
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `pgw`
 --
 
-DROP TABLE IF EXISTS `pgw`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `pgw` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL,
   `ipv4` varchar(15) NOT NULL,
-  `ipv6` varchar(39) NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `ipv4` (`ipv4`),
-  UNIQUE KEY `ipv6` (`ipv6`)
-) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
+  `ipv6` varchar(39) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 --
 -- Dumping data for table `pgw`
 --
 
-LOCK TABLES `pgw` WRITE;
-/*!40000 ALTER TABLE `pgw` DISABLE KEYS */;
-INSERT INTO `pgw` VALUES (1,'127.0.0.1','0:0:0:0:0:0:0:1');
-/*!40000 ALTER TABLE `pgw` ENABLE KEYS */;
-UNLOCK TABLES;
+INSERT INTO `pgw` (`id`, `ipv4`, `ipv6`) VALUES
+(1, '127.0.0.1', '0:0:0:0:0:0:0:1');
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `terminal-info`
 --
 
-DROP TABLE IF EXISTS `terminal-info`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `terminal-info` (
   `imei` varchar(15) NOT NULL,
-  `sv` varchar(2) NOT NULL,
-  UNIQUE KEY `imei` (`imei`)
+  `sv` varchar(2) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
---
--- Dumping data for table `terminal-info`
---
-
-LOCK TABLES `terminal-info` WRITE;
-/*!40000 ALTER TABLE `terminal-info` DISABLE KEYS */;
-/*!40000 ALTER TABLE `terminal-info` ENABLE KEYS */;
-UNLOCK TABLES;
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `users`
 --
 
-DROP TABLE IF EXISTS `users`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
   `imsi` varchar(15) NOT NULL COMMENT 'IMSI is the main reference key.',
   `msisdn` varchar(46) DEFAULT NULL COMMENT 'The basic MSISDN of the UE (Presence of MSISDN is optional).',
   `imei` varchar(15) DEFAULT NULL COMMENT 'International Mobile Equipment Identity',
   `imei_sv` varchar(2) DEFAULT NULL COMMENT 'International Mobile Equipment Identity Software Version Number',
   `ms_ps_status` enum('PURGED','NOT_PURGED') DEFAULT 'PURGED' COMMENT 'Indicates that ESM and EMM status are purged from MME',
-  `rau_tau_timer` int(10) unsigned DEFAULT '120',
-  `ue_ambr_ul` bigint(20) unsigned DEFAULT '50000000' COMMENT 'The Maximum Aggregated uplink MBRs to be shared across all Non-GBR bearers according to the subscription of the user.',
-  `ue_ambr_dl` bigint(20) unsigned DEFAULT '100000000' COMMENT 'The Maximum Aggregated downlink MBRs to be shared across all Non-GBR bearers according to the subscription of the user.',
-  `access_restriction` int(10) unsigned DEFAULT '60' COMMENT 'Indicates the access restriction subscription information. 3GPP TS.29272 #7.3.31',
-  `mme_cap` int(10) unsigned zerofill DEFAULT NULL COMMENT 'Indicates the capabilities of the MME with respect to core functionality e.g. regional access restrictions.',
+  `rau_tau_timer` int(10) UNSIGNED DEFAULT '120',
+  `ue_ambr_ul` bigint(20) UNSIGNED DEFAULT '50000000' COMMENT 'The Maximum Aggregated uplink MBRs to be shared across all Non-GBR bearers according to the subscription of the user.',
+  `ue_ambr_dl` bigint(20) UNSIGNED DEFAULT '100000000' COMMENT 'The Maximum Aggregated downlink MBRs to be shared across all Non-GBR bearers according to the subscription of the user.',
+  `access_restriction` int(10) UNSIGNED DEFAULT '60' COMMENT 'Indicates the access restriction subscription information. 3GPP TS.29272 #7.3.31',
+  `mme_cap` int(10) UNSIGNED ZEROFILL DEFAULT NULL COMMENT 'Indicates the capabilities of the MME with respect to core functionality e.g. regional access restrictions.',
   `mmeidentity_idmmeidentity` int(11) NOT NULL DEFAULT '0',
   `key` varbinary(16) NOT NULL DEFAULT '0' COMMENT 'UE security key',
-  `RFSP-Index` smallint(5) unsigned NOT NULL DEFAULT '1' COMMENT 'An index to specific RRM configuration in the E-UTRAN. Possible values from 1 to 256',
+  `RFSP-Index` smallint(5) UNSIGNED NOT NULL DEFAULT '1' COMMENT 'An index to specific RRM configuration in the E-UTRAN. Possible values from 1 to 256',
   `urrp_mme` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'UE Reachability Request Parameter indicating that UE activity notification from MME has been requested by the HSS.',
-  `sqn` bigint(20) unsigned zerofill NOT NULL,
+  `sqn` bigint(20) UNSIGNED ZEROFILL NOT NULL,
   `rand` varbinary(16) NOT NULL,
-  `OPc` varbinary(16) DEFAULT NULL COMMENT 'Can be computed by HSS',
-  PRIMARY KEY (`imsi`,`mmeidentity_idmmeidentity`),
-  KEY `fk_users_mmeidentity_idx1` (`mmeidentity_idmmeidentity`)
+  `OPc` varbinary(16) DEFAULT NULL COMMENT 'Can be computed by HSS'
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `users`
 --
 
-LOCK TABLES `users` WRITE;
-/*!40000 ALTER TABLE `users` DISABLE KEYS */;
-INSERT INTO `users` VALUES ('208920100001100','33638020000','35609204079200',NULL,'PURGED',120,50000000,100000000,47,0,1,0x8baf473f2f8fd09487cccbd7097c6862,1,0,351,0x0,0xe734f8734007d6c5ce7a0508809e7e9c);
-/*!40000 ALTER TABLE `users` ENABLE KEYS */;
-UNLOCK TABLES;
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+INSERT INTO `users` (`imsi`, `msisdn`, `imei`, `imei_sv`, `ms_ps_status`, `rau_tau_timer`, `ue_ambr_ul`, `ue_ambr_dl`, `access_restriction`, `mme_cap`, `mmeidentity_idmmeidentity`, `key`, `RFSP-Index`, `urrp_mme`, `sqn`, `rand`, `OPc`) VALUES
+('901550000000000', '6789', '35609204079200', NULL, 'PURGED', 120, 50000000, 100000000, 47, 0000000000, 1, 0x912e7221941577df083e1591d35f4c42, 1, 0, 00000000000000000351, 0x00, 0x8caac204d4ff07140c23ea7f2e191e12),
+('208930100001111', '6789', '356113022094149', NULL, 'NOT_PURGED', 120, 50000000, 100000000, 47, 0000000000, 46, 0x8baf473f2f8fd09487cccbd7097c6862, 1, 0, 00000000000000001727, 0x90b69a4032fc642fc17bfd3462aed44d, 0xe734f8734007d6c5ce7a0508809e7e9c);
 
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+--
+-- Indexes for dumped tables
+--
+
+--
+-- Indexes for table `apn`
+--
+ALTER TABLE `apn`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `apn-name` (`apn-name`);
+
+--
+-- Indexes for table `mmeidentity`
+--
+ALTER TABLE `mmeidentity`
+  ADD PRIMARY KEY (`idmmeidentity`);
+
+--
+-- Indexes for table `pdn`
+--
+ALTER TABLE `pdn`
+  ADD PRIMARY KEY (`id`,`pgw_id`,`users_imsi`),
+  ADD KEY `fk_pdn_pgw1_idx` (`pgw_id`),
+  ADD KEY `fk_pdn_users1_idx` (`users_imsi`);
+
+--
+-- Indexes for table `pgw`
+--
+ALTER TABLE `pgw`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `ipv4` (`ipv4`),
+  ADD UNIQUE KEY `ipv6` (`ipv6`);
+
+--
+-- Indexes for table `terminal-info`
+--
+ALTER TABLE `terminal-info`
+  ADD UNIQUE KEY `imei` (`imei`);
+
+--
+-- Indexes for table `users`
+--
+ALTER TABLE `users`
+  ADD PRIMARY KEY (`imsi`,`mmeidentity_idmmeidentity`),
+  ADD KEY `fk_users_mmeidentity_idx1` (`mmeidentity_idmmeidentity`);
+
+--
+-- AUTO_INCREMENT for dumped tables
+--
+
+--
+-- AUTO_INCREMENT for table `apn`
+--
+ALTER TABLE `apn`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `mmeidentity`
+--
+ALTER TABLE `mmeidentity`
+  MODIFY `idmmeidentity` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=47;
+
+--
+-- AUTO_INCREMENT for table `pdn`
+--
+ALTER TABLE `pdn`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=61;
+
+--
+-- AUTO_INCREMENT for table `pgw`
+--
+ALTER TABLE `pgw`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
+COMMIT;
+
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-
--- Dump completed on 2016-06-28 11:41:40
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,26 @@ services:
         - MYSQL_ROOT_PASSWORD=linux
     domainname: openair4G.eur
     hostname: db
+  iperf3_server:
+    image: networkstatic/iperf3
+    ports:
+        - 5201:5201
+    command: ["-s"]
+    networks:
+      default:
+      epc:
+        ipv4_address: 192.168.142.40
+  iperf3_client:
+    depends_on:
+        - iperf3_server
+    image: networkstatic/iperf3
+    entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c 192.168.142.40 -J > /tmp/iperf_status/status.json; sleep 30;done"
+    volumes:
+     - /tmp/iperf_status:/tmp/iperf_status
+    networks:
+      default:
+      epc:
+        ipv4_address: 192.168.142.41
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,13 +46,12 @@ services:
       networks:
         default:
         epc:
-          ipv4_address: 192.168.142.41
     iperf3_client:
       depends_on:
           - iperf3_server
       image: networkstatic/iperf3
       container_name: oai_iperf3_client
-      entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c 192.168.142.41; sleep 30;done"
+      entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c iperf3_server; sleep 30;done"
       volumes:
        - /tmp/iperf_status:/tmp/iperf_status
       networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,92 +34,92 @@ services:
       networks:
           - monitoring
 
-  #####################
-  # Traffic Generator #
-  #####################
-  iperf3_server:
-    image: networkstatic/iperf3
-    ports:
-        - 5201:5201
-    command: ["-s"]
-    networks:
-      default:
-      epc:
-        ipv4_address: 192.168.142.41
-  iperf3_client:
-    depends_on:
-        - iperf3_server
-    image: networkstatic/iperf3
-    entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c 10.0.5.110 -J; sleep 30;done"
-    volumes:
-     - /tmp/iperf_status:/tmp/iperf_status
-    networks:
-      default:
-      epc:
-
-  ###############
-  # EPC Network #
-  ###############
-  db:
-    build: db
-    ports:
-        - 3306:3306
-    environment:
-        - MYSQL_ROOT_PASSWORD=linux
-    domainname: openair4G.eur
-    hostname: db
-  iperf3_server:
-    image: networkstatic/iperf3
-    ports:
-        - 5201:5201
-    command: ["-s"]
-    networks:
-      default:
-      epc:
-        ipv4_address: 192.168.142.40
-  phpmyadmin:
-    image: phpmyadmin/phpmyadmin
-    links:
-     - db:db
-    ports:
-        - 8088:80
-    environment:
-        - MYSQL_ROOT_PASSWORD=linux
-        - MYSQL_USER=root
-        - MYSQL_PASSWORD=linux
-  hss:
-    build: hss
-    links:
-     - db:db.openair4G.eur
-    networks:
-      default:
-      epc:
-        ipv4_address: 192.168.142.10
-    domainname: openair4G.eur
-    hostname: hss
-  mme:
-    build: mme
-    links:
-     - hss:hss.openair4G.eur
-    networks:
-      epc:
-        ipv4_address: 192.168.142.20
-    domainname: openair4G.eur
-    hostname: mme
-  spgw:
-    build: spgw
-    links:
-     - hss:hss.openair4G.eur
-    networks:
-      epc:
-        ipv4_address: 192.168.142.30
-      sg:
-        ipv4_address: 172.16.0.2
-    privileged: true
-    domainname: openair4G.eur
-    hostname: spgw
-    volumes:
-     - /lib/modules:/lib/modules
+    #####################
+    # Traffic Generator #
+    #####################
+    iperf3_server:
+      image: networkstatic/iperf3
+      ports:
+          - 5201:5201
+      command: ["-s"]
+      networks:
+        default:
+        epc:
+          ipv4_address: 192.168.142.41
+    iperf3_client:
+      depends_on:
+          - iperf3_server
+      image: networkstatic/iperf3
+      entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c 10.0.5.110 -J; sleep 30;done"
+      volumes:
+       - /tmp/iperf_status:/tmp/iperf_status
+      networks:
+        default:
+        epc:
+  
+    ###############
+    # EPC Network #
+    ###############
+    db:
+      build: db
+      ports:
+          - 3306:3306
+      environment:
+          - MYSQL_ROOT_PASSWORD=linux
+      domainname: openair4G.eur
+      hostname: db
+    iperf3_server:
+      image: networkstatic/iperf3
+      ports:
+          - 5201:5201
+      command: ["-s"]
+      networks:
+        default:
+        epc:
+          ipv4_address: 192.168.142.40
+    phpmyadmin:
+      image: phpmyadmin/phpmyadmin
+      links:
+       - db:db
+      ports:
+          - 8088:80
+      environment:
+          - MYSQL_ROOT_PASSWORD=linux
+          - MYSQL_USER=root
+          - MYSQL_PASSWORD=linux
+    hss:
+      build: hss
+      links:
+       - db:db.openair4G.eur
+      networks:
+        default:
+        epc:
+          ipv4_address: 192.168.142.10
+      domainname: openair4G.eur
+      hostname: hss
+    mme:
+      build: mme
+      links:
+       - hss:hss.openair4G.eur
+      networks:
+        epc:
+          ipv4_address: 192.168.142.20
+      domainname: openair4G.eur
+      hostname: mme
+    spgw:
+      build: spgw
+      links:
+       - hss:hss.openair4G.eur
+      networks:
+        epc:
+          ipv4_address: 192.168.142.30
+        sg:
+          ipv4_address: 172.16.0.2
+      privileged: true
+      domainname: openair4G.eur
+      hostname: spgw
+      volumes:
+       - /lib/modules:/lib/modules
 
 networks:
   monitoring:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,16 @@ services:
         - MYSQL_ROOT_PASSWORD=linux
     domainname: openair4G.eur
     hostname: db
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    links:
+     - db:db
+    ports:
+        - 8080:80
+    environment:
+        - MYSQL_ROOT_PASSWORD=linux
+        - MYSQL_USER=root
+        - MYSQL_PASSWORD=linux
   hss:
     build: hss
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       networks:
         default:
         epc:
+          ipv4_address: 192.168.142.40
     iperf3_client:
       depends_on:
           - iperf3_server
@@ -55,7 +56,6 @@ services:
       volumes:
        - /tmp/iperf_status:/tmp/iperf_status
       networks:
-        default:
         epc:
 
     ###############
@@ -69,6 +69,8 @@ services:
           - MYSQL_ROOT_PASSWORD=linux
       domainname: openair4G.eur
       hostname: db
+      volumes:
+       - ./db/oai_db.sql:/docker-entrypoint-initdb.d/oai_db.sql
     phpmyadmin:
       image: phpmyadmin/phpmyadmin
       links:
@@ -89,6 +91,8 @@ services:
           ipv4_address: 192.168.142.10
       domainname: openair4G.eur
       hostname: hss
+      volumes:
+       - ./hss/hss.conf:/usr/local/etc/oai/hss.conf:ro
     mme:
       build: mme
       links:
@@ -98,6 +102,8 @@ services:
           ipv4_address: 192.168.142.20
       domainname: openair4G.eur
       hostname: mme
+      volumes:
+       - ./mme/mme.conf:/usr/local/etc/oai/mme.conf:ro
     spgw:
       build: spgw
       links:
@@ -105,13 +111,12 @@ services:
       networks:
         epc:
           ipv4_address: 192.168.142.30
-        sg:
-          ipv4_address: 172.16.0.2
       privileged: true
       domainname: openair4G.eur
       hostname: spgw
       volumes:
        - /lib/modules:/lib/modules
+       - ./spgw/spgw.conf:/usr/local/etc/oai/spgw.conf:ro
 
 networks:
   monitoring:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,13 +50,13 @@ services:
       depends_on:
           - iperf3_server
       image: networkstatic/iperf3
-      entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c 10.0.5.110 -J; sleep 30;done"
+      entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c 192.168.142.41; sleep 30;done"
       volumes:
        - /tmp/iperf_status:/tmp/iperf_status
       networks:
         default:
         epc:
-  
+
     ###############
     # EPC Network #
     ###############
@@ -68,15 +68,6 @@ services:
           - MYSQL_ROOT_PASSWORD=linux
       domainname: openair4G.eur
       hostname: db
-    iperf3_server:
-      image: networkstatic/iperf3
-      ports:
-          - 5201:5201
-      command: ["-s"]
-      networks:
-        default:
-        epc:
-          ipv4_address: 192.168.142.40
     phpmyadmin:
       image: phpmyadmin/phpmyadmin
       links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       ports:
           - 9090:9090
       volumes:
-          - prometheus.yml:/etc/prometheus/prometheus.yml
+          - ./prometheus.yml:/etc/prometheus/prometheus.yml
       networks:
           - monitoring
     grafana:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,8 @@ services:
      - /lib/modules:/lib/modules
 
 networks:
+  monitoring:
+    driver: bridge
   epc:
     driver: bridge
     ipam:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     #####################
     iperf3_server:
       image: networkstatic/iperf3
+      container_name: oai_iperf3_server
       ports:
           - 5201:5201
       command: ["-s"]
@@ -50,6 +51,7 @@ services:
       depends_on:
           - iperf3_server
       image: networkstatic/iperf3
+      container_name: oai_iperf3_client
       entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c 192.168.142.41; sleep 30;done"
       volumes:
        - /tmp/iperf_status:/tmp/iperf_status

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,65 @@
 version: '2'
 
 services:
+    ######################
+    # Monitring Services #
+    ######################
+    cadvisor:
+      image: google/cadvisor:latest
+      container_name: oai_cadvisor
+      ports:
+          - 8080:8080
+      volumes:
+          - /:/rootfs:ro
+          - /var/run:/var/run:rw
+          - /sys:/sys:ro
+          - /var/lib/docker/:/var/lib/docker:ro
+          - /dev/disk/:/dev/disk:ro
+      networks:
+          - monitoring
+    prometheus:
+      image: prom/prometheus
+      container_name: oai_prometheus
+      ports:
+          - 9090:9090
+      volumes:
+          - prometheus.yml:/etc/prometheus/prometheus.yml
+      networks:
+          - monitoring
+    grafana:
+      image: grafana/grafana
+      container_name: oai_grafana
+      ports:
+          - 3000:3000
+      networks:
+          - monitoring
+
+  #####################
+  # Traffic Generator #
+  #####################
+  iperf3_server:
+    image: networkstatic/iperf3
+    ports:
+        - 5201:5201
+    command: ["-s"]
+    networks:
+      default:
+      epc:
+        ipv4_address: 192.168.142.41
+  iperf3_client:
+    depends_on:
+        - iperf3_server
+    image: networkstatic/iperf3
+    entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c 10.0.5.110 -J; sleep 30;done"
+    volumes:
+     - /tmp/iperf_status:/tmp/iperf_status
+    networks:
+      default:
+      epc:
+
+  ###############
+  # EPC Network #
+  ###############
   db:
     build: db
     ports:
@@ -18,23 +77,12 @@ services:
       default:
       epc:
         ipv4_address: 192.168.142.40
-  iperf3_client:
-    depends_on:
-        - iperf3_server
-    image: networkstatic/iperf3
-    entrypoint: bash -x -c "while true;do /usr/bin/iperf3 -c 192.168.142.40 -J > /tmp/iperf_status/status.json; sleep 30;done"
-    volumes:
-     - /tmp/iperf_status:/tmp/iperf_status
-    networks:
-      default:
-      epc:
-        ipv4_address: 192.168.142.41
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     links:
      - db:db
     ports:
-        - 8080:80
+        - 8088:80
     environment:
         - MYSQL_ROOT_PASSWORD=linux
         - MYSQL_USER=root
@@ -49,7 +97,7 @@ services:
         ipv4_address: 192.168.142.10
     domainname: openair4G.eur
     hostname: hss
-  mme: 
+  mme:
     build: mme
     links:
      - hss:hss.openair4G.eur
@@ -58,7 +106,7 @@ services:
         ipv4_address: 192.168.142.20
     domainname: openair4G.eur
     hostname: mme
-  spgw: 
+  spgw:
     build: spgw
     links:
      - hss:hss.openair4G.eur
@@ -71,7 +119,8 @@ services:
     domainname: openair4G.eur
     hostname: spgw
     volumes:
-     - /lib/modules:/lib/modules 
+     - /lib/modules:/lib/modules
+
 networks:
   epc:
     driver: bridge

--- a/hss/Dockerfile
+++ b/hss/Dockerfile
@@ -114,24 +114,16 @@ RUN cp /root/openair-cn/etc/hss.conf /usr/local/etc/oai/
 RUN cp /root/openair-cn/etc/hss_fd.conf /usr/local/etc/oai/freeDiameter/
 RUN cp /root/openair-cn/etc/acl.conf /usr/local/etc/oai/freeDiameter/
 
-# MySQL database configuration 
-RUN sed -i "s/@MYSQL_user@/$MYSQLUSER/g" /usr/local/etc/oai/hss.conf
-RUN sed -i "s/@MYSQL_pass@/$MYSQLPASSWORD/g" /usr/local/etc/oai/hss.conf
-RUN sed -i "s/127.0.0.1/$MYSQLHOSTNAME/g" /usr/local/etc/oai/hss.conf
-RUN sed -i "s/oai_db/$MYSQLDATABASE/g" /usr/local/etc/oai/hss.conf
+ENV MYSQLUSER=root
+ENV MYSQLPASSWORD=linux
+ENV MYSQLDATABASE=oai_db
+ENV MYSQLHOSTNAME=db.openair4G.eur
 
-# Operator key (OP)
-RUN sed -i "s/1006020f0a478bf6b699f15c062e42b3/$OPKEY/g" /usr/local/etc/oai/hss.conf
+ENV OPKEY=63bfa50ee6523365ff14c1f45f88737d
 
-# Generation of certificate for diameter 
-WORKDIR /root/
-RUN mkdir demoCA && touch demoCA/index.txt && echo 01 > demoCA/serial
-RUN openssl req  -new -batch -x509 -days 3650 -nodes -newkey rsa:1024 -out hss.cacert.pem -keyout hss.cakey.pem -subj /CN=$HSS_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
-RUN openssl genrsa -out hss.key.pem 1024
-RUN openssl req -new -batch -out hss.csr.pem -key hss.key.pem -subj /CN=$HSS_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
-RUN openssl ca -cert hss.cacert.pem -keyfile hss.cakey.pem -in hss.csr.pem -out hss.cert.pem -outdir . -batch
-RUN mv hss.cakey.pem hss.cert.pem hss.cacert.pem hss.key.pem /usr/local/etc/oai/freeDiameter/
-
+ENV HSS_CN_NAME=hss.openair4G.eur
 #ready to work
 WORKDIR /root
-ENTRYPOINT bash -x -c "sleep 15 && /root/openair-cn/build/hss/build/oai_hss"
+COPY start.sh /root/start.sh
+RUN chmod +x /root/start.sh
+ENTRYPOINT "/root/start.sh"

--- a/hss/Dockerfile
+++ b/hss/Dockerfile
@@ -110,18 +110,18 @@ RUN cmake -DOPENAIRCN_DIR=/root/openair-cn ../
 RUN make -j`nproc`
 
 RUN mkdir -p /usr/local/etc/oai/freeDiameter
-RUN cp /root/openair-cn/etc/hss.conf /usr/local/etc/oai/
+# RUN cp /root/openair-cn/etc/hss.conf /usr/local/etc/oai/
 RUN cp /root/openair-cn/etc/hss_fd.conf /usr/local/etc/oai/freeDiameter/
 RUN cp /root/openair-cn/etc/acl.conf /usr/local/etc/oai/freeDiameter/
 
 # MySQL database configuration 
-RUN sed -i "s/@MYSQL_user@/$MYSQLUSER/g" /usr/local/etc/oai/hss.conf
-RUN sed -i "s/@MYSQL_pass@/$MYSQLPASSWORD/g" /usr/local/etc/oai/hss.conf
-RUN sed -i "s/127.0.0.1/$MYSQLHOSTNAME/g" /usr/local/etc/oai/hss.conf
-RUN sed -i "s/oai_db/$MYSQLDATABASE/g" /usr/local/etc/oai/hss.conf
+# RUN sed -i "s/@MYSQL_user@/$MYSQLUSER/g" /usr/local/etc/oai/hss.conf
+# RUN sed -i "s/@MYSQL_pass@/$MYSQLPASSWORD/g" /usr/local/etc/oai/hss.conf
+# RUN sed -i "s/127.0.0.1/$MYSQLHOSTNAME/g" /usr/local/etc/oai/hss.conf
+# RUN sed -i "s/oai_db/$MYSQLDATABASE/g" /usr/local/etc/oai/hss.conf
 
 # Operator key (OP)
-RUN sed -i "s/1006020f0a478bf6b699f15c062e42b3/$OPKEY/g" /usr/local/etc/oai/hss.conf
+# RUN sed -i "s/1006020f0a478bf6b699f15c062e42b3/$OPKEY/g" /usr/local/etc/oai/hss.conf
 
 # Generation of certificate for diameter 
 WORKDIR /root/

--- a/hss/hss.conf
+++ b/hss/hss.conf
@@ -1,0 +1,38 @@
+################################################################################
+# Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The OpenAirInterface Software Alliance licenses this file to You under 
+# the Apache License, Version 2.0  (the "License"); you may not use this file
+# except in compliance with the License.  
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+# For more information about the OpenAirInterface (OAI) Software Alliance:
+#      contact@openairinterface.org
+################################################################################
+HSS :
+{
+## MySQL mandatory options
+MYSQL_server = "db.openair4G.eur";     # HSS S6a bind address
+MYSQL_user   = "root";  # Database server login
+MYSQL_pass   = "linux";  # Database server password
+MYSQL_db     = "oai_db";        # Your database name 
+
+## HSS options
+# OPERATOR_key = "63bfa50ee6523365ff14c1f45f88737d"; # OP key matching your database
+OPERATOR_key = "1006020f0a478bf6b699f15c062e42b3"; # OP key matching your database
+#OPERATOR_key = "11111111111111111111111111111111"; # OP key matching your database
+
+RANDOM = "true";                                   # True random or only pseudo random (for subscriber vector generation)
+
+## Freediameter options
+FD_conf = "/usr/local/etc/oai/freeDiameter/hss_fd.conf";
+};

--- a/hss/start.sh
+++ b/hss/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# MySQL database configuration 
+# MySQL database configuration
 sed -i "s/@MYSQL_user@/$MYSQLUSER/g" /usr/local/etc/oai/hss.conf
 sed -i "s/@MYSQL_pass@/$MYSQLPASSWORD/g" /usr/local/etc/oai/hss.conf
 sed -i "s/127.0.0.1/$MYSQLHOSTNAME/g" /usr/local/etc/oai/hss.conf
@@ -14,18 +14,19 @@ sed -i "s/hss.openair4G.eur/$HSS_CN_NAME/g" /usr/local/etc/oai/hss.conf
 sed -i "s/hss.openair4G.eur/$HSS_CN_NAME/g" /usr/local/etc/oai/freeDiameter/hss_fd.conf
 sed -i "s/hss.openair4G.eur/$HSS_CN_NAME/g" /usr/local/etc/oai/freeDiameter/acl.conf
 
-
-# Generation of certificate for diameter 
+# Generation of certificate for diameter
 cd /root
-mkdir demoCA && touch demoCA/index.txt && echo 01 > demoCA/serial
-openssl req  -new -batch -x509 -days 3650 -nodes -newkey rsa:1024 -out hss.cacert.pem -keyout hss.cakey.pem -subj /CN=$HSS_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
-openssl genrsa -out hss.key.pem 1024
-openssl req -new -batch -out hss.csr.pem -key hss.key.pem -subj /CN=$HSS_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
-openssl ca -cert hss.cacert.pem -keyfile hss.cakey.pem -in hss.csr.pem -out hss.cert.pem -outdir . -batch
-mv /root/hss.cakey.pem /usr/local/etc/oai/freeDiameter/
-mv /root/hss.cert.pem /usr/local/etc/oai/freeDiameter/
-mv /root/hss.cacert.pem /usr/local/etc/oai/freeDiameter/
-mv /root/hss.key.pem /usr/local/etc/oai/freeDiameter/
+if [[ ! -d /root/demoCA ]];then
+	mkdir demoCA && touch demoCA/index.txt && echo 01 > demoCA/serial
+	openssl req  -new -batch -x509 -days 3650 -nodes -newkey rsa:1024 -out hss.cacert.pem -keyout hss.cakey.pem -subj /CN=$HSS_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
+	openssl genrsa -out hss.key.pem 1024
+	openssl req -new -batch -out hss.csr.pem -key hss.key.pem -subj /CN=$HSS_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
+	openssl ca -cert hss.cacert.pem -keyfile hss.cakey.pem -in hss.csr.pem -out hss.cert.pem -outdir . -batch
+	mv /root/hss.cakey.pem /usr/local/etc/oai/freeDiameter/
+	mv /root/hss.cert.pem /usr/local/etc/oai/freeDiameter/
+	mv /root/hss.cacert.pem /usr/local/etc/oai/freeDiameter/
+	mv /root/hss.key.pem /usr/local/etc/oai/freeDiameter/
+fi
 
 # Start hss
 sleep 15 && /root/openair-cn/build/hss/build/oai_hss

--- a/hss/start.sh
+++ b/hss/start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# MySQL database configuration 
+sed -i "s/@MYSQL_user@/$MYSQLUSER/g" /usr/local/etc/oai/hss.conf
+sed -i "s/@MYSQL_pass@/$MYSQLPASSWORD/g" /usr/local/etc/oai/hss.conf
+sed -i "s/127.0.0.1/$MYSQLHOSTNAME/g" /usr/local/etc/oai/hss.conf
+sed -i "s/oai_db/$MYSQLDATABASE/g" /usr/local/etc/oai/hss.conf
+sed -i "s/db.openair4G.eur/$MYSQLHOSTNAME/g" /usr/local/etc/oai/hss.conf
+
+# Operator key (OP)
+sed -i "s/1006020f0a478bf6b699f15c062e42b3/$OPKEY/g" /usr/local/etc/oai/hss.conf
+
+# HSS Configuration
+sed -i "s/hss.openair4G.eur/$HSS_CN_NAME/g" /usr/local/etc/oai/hss.conf
+sed -i "s/hss.openair4G.eur/$HSS_CN_NAME/g" /usr/local/etc/oai/freeDiameter/hss_fd.conf
+sed -i "s/hss.openair4G.eur/$HSS_CN_NAME/g" /usr/local/etc/oai/freeDiameter/acl.conf
+
+
+# Generation of certificate for diameter 
+cd /root
+mkdir demoCA && touch demoCA/index.txt && echo 01 > demoCA/serial
+openssl req  -new -batch -x509 -days 3650 -nodes -newkey rsa:1024 -out hss.cacert.pem -keyout hss.cakey.pem -subj /CN=$HSS_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
+openssl genrsa -out hss.key.pem 1024
+openssl req -new -batch -out hss.csr.pem -key hss.key.pem -subj /CN=$HSS_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
+openssl ca -cert hss.cacert.pem -keyfile hss.cakey.pem -in hss.csr.pem -out hss.cert.pem -outdir . -batch
+mv /root/hss.cakey.pem /usr/local/etc/oai/freeDiameter/
+mv /root/hss.cert.pem /usr/local/etc/oai/freeDiameter/
+mv /root/hss.cacert.pem /usr/local/etc/oai/freeDiameter/
+mv /root/hss.key.pem /usr/local/etc/oai/freeDiameter/
+
+# Start hss
+sleep 15 && /root/openair-cn/build/hss/build/oai_hss

--- a/mme/Dockerfile
+++ b/mme/Dockerfile
@@ -171,17 +171,14 @@ RUN make -j`nproc`
 RUN mkdir -p /usr/local/etc/oai/freeDiameter
 RUN cp /root/openair-cn/etc/mme.conf /usr/local/etc/oai/
 RUN cp /root/openair-cn/etc/mme_fd.conf /usr/local/etc/oai/freeDiameter/
-RUN sed -i s/"192.168.11.17\/24"/"192.168.142.20\/24"/g /usr/local/etc/oai/mme.conf
-RUN sed -i s/"yang.openair4G.eur"/"mme.openair4G.eur"/g /usr/local/etc/oai/freeDiameter/mme_fd.conf
-RUN sed -i s/"127.0.0.1"/"192.168.142.10"/g /usr/local/etc/oai/freeDiameter/mme_fd.conf
 
-# Generation of certificate for diameter 
-WORKDIR /root/
-RUN mkdir demoCA && touch demoCA/index.txt && echo 01 > demoCA/serial
-RUN openssl req  -new -batch -x509 -days 3650 -nodes -newkey rsa:1024 -out mme.cacert.pem -keyout mme.cakey.pem -subj /CN=mme.openair4G.eur/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
-RUN openssl genrsa -out mme.key.pem 1024
-RUN openssl req -new -batch -out mme.csr.pem -key mme.key.pem -subj /CN=mme.openair4G.eur/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
-RUN openssl ca -cert mme.cacert.pem -keyfile mme.cakey.pem -in mme.csr.pem -out mme.cert.pem -outdir . -batch
-RUN mv mme.cakey.pem mme.cert.pem mme.cacert.pem mme.key.pem /usr/local/etc/oai/freeDiameter/
+ENV HSS_CN_NAME=hss.openair4G.eur
+ENV MME_CN_NAME=mme.openair4G.eur
+ENV MME_IPV4_ADDRESS_FOR_S1_MME="192.168.142.20"
+ENV HSS_IPV4_ADDRESS="192.168.142.10"
 
-ENTRYPOINT bash -x -c "sleep 17 &&  /root/openair-cn/build/mme/build/mme"
+#ready to work
+WORKDIR /root
+COPY start.sh /root/start.sh
+RUN chmod +x /root/start.sh
+ENTRYPOINT "/root/start.sh"

--- a/mme/Dockerfile
+++ b/mme/Dockerfile
@@ -169,9 +169,9 @@ RUN make -j`nproc`
 
 # Configuration files
 RUN mkdir -p /usr/local/etc/oai/freeDiameter
-RUN cp /root/openair-cn/etc/mme.conf /usr/local/etc/oai/
+# RUN cp /root/openair-cn/etc/mme.conf /usr/local/etc/oai/
 RUN cp /root/openair-cn/etc/mme_fd.conf /usr/local/etc/oai/freeDiameter/
-RUN sed -i s/"192.168.11.17\/24"/"192.168.142.20\/24"/g /usr/local/etc/oai/mme.conf
+# RUN sed -i s/"192.168.11.17\/24"/"192.168.142.20\/24"/g /usr/local/etc/oai/mme.conf
 RUN sed -i s/"yang.openair4G.eur"/"mme.openair4G.eur"/g /usr/local/etc/oai/freeDiameter/mme_fd.conf
 RUN sed -i s/"127.0.0.1"/"192.168.142.10"/g /usr/local/etc/oai/freeDiameter/mme_fd.conf
 

--- a/mme/mme.conf
+++ b/mme/mme.conf
@@ -1,0 +1,209 @@
+################################################################################
+# Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The OpenAirInterface Software Alliance licenses this file to You under 
+# the Apache License, Version 2.0  (the "License"); you may not use this file
+# except in compliance with the License.  
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+# For more information about the OpenAirInterface (OAI) Software Alliance:
+#      contact@openairinterface.org
+################################################################################
+
+MME : 
+{
+    REALM                                     = "openair4G.eur";                # YOUR REALM HERE
+    PID_DIRECTORY                             = "/var/run";
+    # Define the limits of the system in terms of served eNB and served UE.
+    # When the limits will be reached, overload procedure will take place.
+    MAXENB                                    = 2;                              # power of 2
+    MAXUE                                     = 16;                             # power of 2
+    RELATIVE_CAPACITY                         = 10;
+    
+    EMERGENCY_ATTACH_SUPPORTED                     = "no";
+    UNAUTHENTICATED_IMSI_SUPPORTED                 = "no";
+    
+    # EPS network feature support
+    EPS_NETWORK_FEATURE_SUPPORT_IMS_VOICE_OVER_PS_SESSION_IN_S1      = "no";    # DO NOT CHANGE
+    EPS_NETWORK_FEATURE_SUPPORT_EMERGENCY_BEARER_SERVICES_IN_S1_MODE = "no";    # DO NOT CHANGE
+    EPS_NETWORK_FEATURE_SUPPORT_LOCATION_SERVICES_VIA_EPC            = "no";    # DO NOT CHANGE
+    EPS_NETWORK_FEATURE_SUPPORT_EXTENDED_SERVICE_REQUEST             = "no";    # DO NOT CHANGE
+    
+    # Display statistics about whole system (expressed in seconds)
+    MME_STATISTIC_TIMER                       = 10;
+    
+    IP_CAPABILITY = "IPV4V6";                                                   # UNUSED, TODO
+    
+    
+    INTERTASK_INTERFACE :
+    {
+        # max queue size per task
+        ITTI_QUEUE_SIZE            = 2000000;
+    };
+
+    S6A :
+    {
+        S6A_CONF                   = "/usr/local/etc/oai/freeDiameter/mme_fd.conf"; # YOUR MME freeDiameter config file path
+        HSS_HOSTNAME               = "hss";                                     # THE HSS HOSTNAME
+    };
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 8;
+        SCTP_OUTSTREAMS = 8;
+    };
+
+    # ------- S1AP definitions
+    S1AP : 
+    {
+        # outcome drop timer value (seconds)
+        S1AP_OUTCOME_TIMER = 10;
+    };
+
+    # ------- MME served GUMMEIs
+    # MME code DEFAULT  size = 8 bits
+    # MME GROUP ID size = 16 bits
+    GUMMEI_LIST = ( 
+         {MCC="208" ; MNC="93"; MME_GID="4" ; MME_CODE="1"; }                   # YOUR GUMMEI CONFIG HERE
+    );
+
+    # ------- MME served TAIs
+    # TA (mcc.mnc:tracking area code) DEFAULT = 208.34:1
+    # max values = 999.999:65535
+    # maximum of 16 TAIs, comma separated
+    # !!! Actually use only one PLMN
+    TAI_LIST = ( 
+         {MCC="208" ; MNC="93";  TAC = "1"; }                                 # YOUR TAI CONFIG HERE
+    );
+    
+    
+    NAS :
+    {
+        # 3GPP TS 33.401 section 7.2.4.3 Procedures for NAS algorithm selection
+        # decreasing preference goes from left to right
+        ORDERED_SUPPORTED_INTEGRITY_ALGORITHM_LIST = [ "EIA2" , "EIA1" , "EIA0" ];
+        ORDERED_SUPPORTED_CIPHERING_ALGORITHM_LIST = [ "EEA0" , "EEA1" , "EEA2" ];
+        
+        # EMM TIMERS
+        # T3402 start:
+        # At attach failure and the attempt counter is equal to 5.
+        # At tracking area updating failure and the attempt counter is equal to 5.
+        # T3402 stop:
+        # ATTACH REQUEST sent, TRACKING AREA REQUEST sent.
+        # On expiry:
+        # Initiation of the attach procedure, if still required or TAU procedure
+        # attached for emergency bearer services.
+        T3402                                 =  1                              # in minutes (default is 12 minutes)
+        
+        # T3412 start:
+        # In EMM-REGISTERED, when EMM-CONNECTED mode is left.
+        # T3412 stop:
+        # When entering state EMM-DEREGISTERED or when entering EMM-CONNECTED mode.
+        # On expiry:
+        # Initiation of the periodic TAU procedure if the UE is not attached for
+        # emergency bearer services. Implicit detach from network if the UE is
+        # attached for emergency bearer services.
+        T3412                                 =  54                             # in minutes (default is 54 minutes, network dependent)
+        # T3422 start: DETACH REQUEST sent
+        # T3422 stop: DETACH ACCEPT received
+        # ON THE 1st, 2nd, 3rd, 4th EXPIRY: Retransmission of DETACH REQUEST
+        T3422                                 =  6                              # in seconds (default is 6s)
+        
+        # T3450 start:
+        # ATTACH ACCEPT sent, TRACKING AREA UPDATE ACCEPT sent with GUTI, TRACKING AREA UPDATE ACCEPT sent with TMSI,
+        # GUTI REALLOCATION COMMAND sent
+        # T3450 stop:
+        # ATTACH COMPLETE received, TRACKING AREA UPDATE COMPLETE received, GUTI REALLOCATION COMPLETE received
+        # ON THE 1st, 2nd, 3rd, 4th EXPIRY: Retransmission of the same message type
+        T3450                                 =  6                              # in seconds (default is 6s)
+        
+        # T3460 start: AUTHENTICATION REQUEST sent, SECURITY MODE COMMAND sent
+        # T3460 stop: 
+        # AUTHENTICATION RESPONSE received, AUTHENTICATION FAILURE received, 
+        # SECURITY MODE COMPLETE received, SECURITY MODE REJECT received
+        # ON THE 1st, 2nd, 3rd, 4th EXPIRY: Retransmission of the same message type
+        T3460                                 =  6                              # in seconds (default is 6s)
+        
+        # T3470 start: IDENTITY REQUEST sent
+        # T3470 stop: IDENTITY RESPONSE received
+        # ON THE 1st, 2nd, 3rd, 4th EXPIRY: Retransmission of IDENTITY REQUEST
+        T3470                                 =  6                              # in seconds (default is 6s)
+        
+        # ESM TIMERS
+        T3485                                 =  8                              # UNUSED in seconds (default is 8s)
+        T3486                                 =  8                              # UNUSED in seconds (default is 8s)
+        T3489                                 =  4                              # UNUSED in seconds (default is 4s)
+        T3495                                 =  8                              # UNUSED in seconds (default is 8s)
+    };
+    
+    NETWORK_INTERFACES : 
+    {
+        # MME binded interface for S1-C or S1-MME  communication (S1AP), can be ethernet interface, virtual ethernet interface, we don't advise wireless interfaces
+        MME_INTERFACE_NAME_FOR_S1_MME         = "eth0";                         # YOUR NETWORK CONFIG HERE
+        MME_IPV4_ADDRESS_FOR_S1_MME           = "192.168.142.20/24";             # YOUR NETWORK CONFIG HERE
+
+        # MME binded interface for S11 communication (GTPV2-C)
+        MME_INTERFACE_NAME_FOR_S11_MME        = "eth0";                           # YOUR NETWORK CONFIG HERE
+        MME_IPV4_ADDRESS_FOR_S11_MME          = "192.168.142.20/24";                 # YOUR NETWORK CONFIG HERE
+        MME_PORT_FOR_S11_MME                  = 2123;                           # YOUR NETWORK CONFIG HERE
+    };
+    
+    LOGGING :
+    {
+        # OUTPUT choice in { "CONSOLE", "SYSLOG", `path to file`", "`IPv4@`:`TCP port num`"} 
+        # `path to file` must start with '.' or '/'
+        # if TCP stream choice, then you can easily dump the traffic on the remote or local host: nc -l `TCP port num` > received.txt
+        OUTPUT            = "CONSOLE";
+        #OUTPUT            = "SYSLOG";
+        #OUTPUT            = "/tmp/mme.log";
+        #OUTPUT            = "127.0.0.1:5656";
+        
+        # THREAD_SAFE choice in { "yes", "no" } means use of thread safe intermediate buffer then a single thread pick each message log one
+        # by one to flush it to the chosen output
+        THREAD_SAFE       = "yes";
+        
+        # COLOR choice in { "yes", "no" } means use of ANSI styling codes or no
+        COLOR             = "yes";                                             
+        
+        # Log level choice in { "EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG", "TRACE"} 
+        SCTP_LOG_LEVEL    = "TRACE";
+        S11_LOG_LEVEL     = "TRACE";
+        GTPV2C_LOG_LEVEL  = "TRACE";
+        UDP_LOG_LEVEL     = "TRACE";
+        S1AP_LOG_LEVEL    = "TRACE";
+        NAS_LOG_LEVEL     = "TRACE";
+        MME_APP_LOG_LEVEL = "TRACE";
+        S6A_LOG_LEVEL     = "TRACE";
+        UTIL_LOG_LEVEL    = "TRACE";
+        MSC_LOG_LEVEL     = "ERROR";
+        ITTI_LOG_LEVEL    = "ERROR";
+        MME_SCENARIO_PLAYER_LOG_LEVEL = "TRACE";
+        
+        # ASN1 VERBOSITY: none, info, annoying
+        # for S1AP protocol
+        ASN1_VERBOSITY    = "none";
+    };
+    TESTING :
+    {
+        # file should be copied here from source tree by following command: run_mme --install-mme-files ...
+        SCENARIO_FILE = "/usr/local/share/oai/test/mme/no_regression.xml";
+    };
+};
+
+S-GW : 
+{
+    # S-GW binded interface for S11 communication (GTPV2-C), if none selected the ITTI message interface is used
+    SGW_IPV4_ADDRESS_FOR_S11                = "192.168.142.30/8";                   # YOUR NETWORK CONFIG HERE
+
+};

--- a/mme/start.sh
+++ b/mme/start.sh
@@ -10,17 +10,18 @@ sed -i s/"192.168.11.17"/"$MME_IPV4_ADDRESS_FOR_S1_MME"/g /usr/local/etc/oai/mme
 sed -i s/"127.0.0.1"/"$HSS_IPV4_ADDRESS"/g /usr/local/etc/oai/freeDiameter/mme_fd.conf
 
 
-# Generation of certificate for diameter 
+# Generation of certificate for diameter
 cd /root
-mkdir demoCA && touch demoCA/index.txt && echo 01 > demoCA/serial
-openssl req  -new -batch -x509 -days 3650 -nodes -newkey rsa:1024 -out mme.cacert.pem -keyout mme.cakey.pem -subj /CN=$MME_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
-openssl genrsa -out mme.key.pem 1024
-openssl req -new -batch -out mme.csr.pem -key mme.key.pem -subj /CN=$MME_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
-openssl ca -cert mme.cacert.pem -keyfile mme.cakey.pem -in mme.csr.pem -out mme.cert.pem -outdir . -batch
-mv /root/mme.cakey.pem /usr/local/etc/oai/freeDiameter/
-mv /root/mme.cert.pem /usr/local/etc/oai/freeDiameter/
-mv /root/mme.cacert.pem /usr/local/etc/oai/freeDiameter/
-mv /root/mme.key.pem /usr/local/etc/oai/freeDiameter/
-
+if [[ ! -d /root/demoCA ]];then
+  mkdir demoCA && touch demoCA/index.txt && echo 01 > demoCA/serial
+  openssl req  -new -batch -x509 -days 3650 -nodes -newkey rsa:1024 -out mme.cacert.pem -keyout mme.cakey.pem -subj /CN=$MME_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
+  openssl genrsa -out mme.key.pem 1024
+  openssl req -new -batch -out mme.csr.pem -key mme.key.pem -subj /CN=$MME_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
+  openssl ca -cert mme.cacert.pem -keyfile mme.cakey.pem -in mme.csr.pem -out mme.cert.pem -outdir . -batch
+  mv /root/mme.cakey.pem /usr/local/etc/oai/freeDiameter/
+  mv /root/mme.cert.pem /usr/local/etc/oai/freeDiameter/
+  mv /root/mme.cacert.pem /usr/local/etc/oai/freeDiameter/
+  mv /root/mme.key.pem /usr/local/etc/oai/freeDiameter/
+fi
 # Start mme
 sleep 17 && /root/openair-cn/build/mme/build/mme

--- a/mme/start.sh
+++ b/mme/start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# MME Configuration
+sed -i s/"mme.openair4G.eur"/$MME_CN_NAME/g /usr/local/etc/oai/mme.conf
+sed -i s/"yang.openair4G.eur"/$MME_CN_NAME/g /usr/local/etc/oai/freeDiameter/mme_fd.conf
+sed -i s/"mme.openair4G.eur"/$MME_CN_NAME/g /usr/local/etc/oai/freeDiameter/mme_fd.conf
+sed -i s/"hss.openair4G.eur"/$HSS_CN_NAME/g /usr/local/etc/oai/freeDiameter/mme_fd.conf
+
+# set IP addr
+sed -i s/"192.168.11.17"/"$MME_IPV4_ADDRESS_FOR_S1_MME"/g /usr/local/etc/oai/mme.conf
+sed -i s/"127.0.0.1"/"$HSS_IPV4_ADDRESS"/g /usr/local/etc/oai/freeDiameter/mme_fd.conf
+
+
+# Generation of certificate for diameter 
+cd /root
+mkdir demoCA && touch demoCA/index.txt && echo 01 > demoCA/serial
+openssl req  -new -batch -x509 -days 3650 -nodes -newkey rsa:1024 -out mme.cacert.pem -keyout mme.cakey.pem -subj /CN=$MME_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
+openssl genrsa -out mme.key.pem 1024
+openssl req -new -batch -out mme.csr.pem -key mme.key.pem -subj /CN=$MME_CN_NAME/C=FR/ST=PACA/L=Aix/O=Eurecom/OU=CM
+openssl ca -cert mme.cacert.pem -keyfile mme.cakey.pem -in mme.csr.pem -out mme.cert.pem -outdir . -batch
+mv /root/mme.cakey.pem /usr/local/etc/oai/freeDiameter/
+mv /root/mme.cert.pem /usr/local/etc/oai/freeDiameter/
+mv /root/mme.cacert.pem /usr/local/etc/oai/freeDiameter/
+mv /root/mme.key.pem /usr/local/etc/oai/freeDiameter/
+
+# Start mme
+sleep 17 && /root/openair-cn/build/mme/build/mme

--- a/oaisim/enb.band7.generic.oaisim.local_mme.conf
+++ b/oaisim/enb.band7.generic.oaisim.local_mme.conf
@@ -1,0 +1,184 @@
+Active_eNBs = ( "eNB_Eurecom_LTEBox");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+eNBs =
+(
+ {
+    ////////// Identification parameters:
+    eNB_ID    =  0xe00;
+
+    cell_type =  "CELL_MACRO_ENB";
+
+    eNB_name  =  "eNB_Eurecom_LTEBox";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  "1";
+
+    mobile_country_code =  "208";
+
+    mobile_network_code =  "93";
+
+       ////////// Physical parameters:
+
+    component_carriers = (
+      {
+            node_function                                         = "eNodeB_3GPP";
+            node_timing                                           = "synch_to_ext_device";
+            node_synch_ref                                        = 0;
+
+  		    frame_type					              = "FDD";
+            tdd_config 					              = 3;
+            tdd_config_s            			      = 0;
+ 			prefix_type             			      = "NORMAL";
+  			eutra_band              			      = 7;
+            downlink_frequency      			      = 2680000000L;
+            uplink_frequency_offset 			      = -120000000;
+  			Nid_cell					              = 0;
+            N_RB_DL                 			      = 25;
+            Nid_cell_mbsfn          			      = 0;
+	    nb_antenna_ports				      = 2;
+            nb_antennas_tx          			      = 2;
+            nb_antennas_rx          			      = 2;
+			tx_gain                                   = 25;
+			rx_gain                                   = 20;
+            prach_root              			      = 0;
+            prach_config_index      			      = 0;
+            prach_high_speed        			      = "DISABLE";
+  	        prach_zero_correlation  			      = 1;
+            prach_freq_offset       			      = 2;
+			pucch_delta_shift       			      = 1;
+            pucch_nRB_CQI           			      = 1;
+            pucch_nCS_AN            			      = 0;
+            pucch_n1_AN             			      = 32;
+            pdsch_referenceSignalPower 			      = 0;
+            pdsch_p_b                  			      = 0;
+            pusch_n_SB                 			      = 1;
+            pusch_enable64QAM          			      = "DISABLE";
+			pusch_hoppingMode                         = "interSubFrame";
+			pusch_hoppingOffset                       = 0;
+     	    pusch_groupHoppingEnabled  			      = "ENABLE";
+	        pusch_groupAssignment      			      = 0;
+	        pusch_sequenceHoppingEnabled		   	  = "DISABLE";
+	        pusch_nDMRS1                              = 0;
+	        phich_duration                            = "NORMAL";
+	        phich_resource                            = "ONESIXTH";
+	        srs_enable                                = "DISABLE";
+	        /*  srs_BandwidthConfig                   =;
+	        srs_SubframeConfig                        =;
+	        srs_ackNackST                             =;
+	        srs_MaxUpPts                              =;*/
+
+	        pusch_p0_Nominal                          = -108;
+	        pusch_alpha                               = "AL1";
+	        pucch_p0_Nominal                          = -108;
+	        msg3_delta_Preamble                       = 6;
+	        pucch_deltaF_Format1                      = "deltaF2";
+	        pucch_deltaF_Format1b                     = "deltaF3";
+	        pucch_deltaF_Format2                      = "deltaF0";
+	        pucch_deltaF_Format2a                     = "deltaF0";
+  	        pucch_deltaF_Format2b		    	      = "deltaF0";
+
+            rach_numberOfRA_Preambles                 = 64;
+            rach_preamblesGroupAConfig                = "DISABLE";
+/*
+            rach_sizeOfRA_PreamblesGroupA             = ;
+            rach_messageSizeGroupA                    = ;
+            rach_messagePowerOffsetGroupB             = ;
+*/
+            rach_powerRampingStep                     = 2;
+            rach_preambleInitialReceivedTargetPower   = -100;
+            rach_preambleTransMax                     = 10;
+            rach_raResponseWindowSize                 = 10;
+            rach_macContentionResolutionTimer         = 48;
+            rach_maxHARQ_Msg3Tx                       = 4;
+
+            pcch_default_PagingCycle                  = 128;
+            pcch_nB                                   = "oneT";
+            bcch_modificationPeriodCoeff			  = 2;
+            ue_TimersAndConstants_t300			      = 1000;
+            ue_TimersAndConstants_t301			      = 1000;
+            ue_TimersAndConstants_t310			      = 1000;
+            ue_TimersAndConstants_t311			      = 10000;
+            ue_TimersAndConstants_n310			      = 20;
+	    ue_TimersAndConstants_n311			      = 1;
+
+	    ue_TransmissionMode				      = 2;		
+        }
+    );
+
+
+    srb1_parameters :
+    {
+        # timer_poll_retransmit = (ms) [5, 10, 15, 20,... 250, 300, 350, ... 500] 
+        timer_poll_retransmit    = 80;
+        
+        # timer_reordering = (ms) [0,5, ... 100, 110, 120, ... ,200]
+        timer_reordering         = 35;
+        
+        # timer_reordering = (ms) [0,5, ... 250, 300, 350, ... ,500]
+        timer_status_prohibit    = 0;
+        
+        # poll_pdu = [4, 8, 16, 32 , 64, 128, 256, infinity(>10000)]
+        poll_pdu                 =  4;
+        
+        # poll_byte = (kB) [25,50,75,100,125,250,375,500,750,1000,1250,1500,2000,3000,infinity(>10000)]
+        poll_byte                =  99999;
+        
+        # max_retx_threshold = [1, 2, 3, 4 , 6, 8, 16, 32]
+        max_retx_threshold       =  4;
+    }
+    
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+    
+    ////////// MME parameters:
+    mme_ip_address      = ( { ipv4       = "192.168.142.20";
+                              ipv6       = "192:168:30::17";
+                              active     = "yes";
+                              preference = "ipv4";
+                            }
+                          );
+
+    NETWORK_INTERFACES :
+    {
+        ENB_INTERFACE_NAME_FOR_S1_MME            = "br-e5c97ccdc66e";
+        ENB_IPV4_ADDRESS_FOR_S1_MME              = "192.168.142.1/24";
+
+        ENB_INTERFACE_NAME_FOR_S1U               = "br-e5c97ccdc66e";
+        ENB_IPV4_ADDRESS_FOR_S1U                 = "192.168.142.1/24";
+        ENB_PORT_FOR_S1U                         = 2152; # Spec 2152
+    };
+
+    log_config :
+    {
+    global_log_level                      ="trace";
+    global_log_verbosity                  ="medium";
+    hw_log_level                          ="info";
+    hw_log_verbosity                      ="medium";
+    phy_log_level                         ="trace";
+    phy_log_verbosity                     ="medium";
+    mac_log_level                         ="trace";
+    mac_log_verbosity                     ="medium";
+    rlc_log_level                         ="trace";
+    rlc_log_verbosity                     ="medium";
+    pdcp_log_level                        ="trace";
+    pdcp_log_verbosity                    ="medium";
+    rrc_log_level                         ="trace";
+    rrc_log_verbosity                     ="medium";
+    gtpu_log_level                        ="debug";
+    gtpu_log_verbosity                    ="medium";
+    udp_log_level                         ="debug";
+    udp_log_verbosity                     ="medium";
+    osa_log_level                         ="debug";
+    osa_log_verbosity                     ="low";
+
+   };
+
+  }
+);

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  # How frequently to scrape targets by default.
+  scrape_interval: 15s
+
+  # The labels to add to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'epc-monitor'
+
+# A list of scrape configurations.
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'cadvisor'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['cadvisor:8080']

--- a/spgw/Dockerfile
+++ b/spgw/Dockerfile
@@ -214,9 +214,9 @@ RUN make -j`nproc`
 
 
 RUN mkdir -p /usr/local/etc/oai/freeDiameter
-RUN cp /root/openair-cn/etc/spgw.conf /usr/local/etc/oai/
-RUN sed -i s/"192.168.11.17"/"192.168.142.30"/g /usr/local/etc/oai/spgw.conf
-RUN sed -i s/"eth3"/"eth1"/g /usr/local/etc/oai/spgw.conf
+# RUN cp /root/openair-cn/etc/spgw.conf /usr/local/etc/oai/
+# RUN sed -i s/"192.168.11.17"/"192.168.142.30"/g /usr/local/etc/oai/spgw.conf
+# RUN sed -i s/"eth3"/"eth1"/g /usr/local/etc/oai/spgw.conf
 
 #  PGW_INTERFACE_NAME_FOR_SGI            = "eth3";                         # STRING, YOUR NETWORK CONFIG HERE
 #        PGW_MASQUERADE_SGI                    = "no";                           # STRING, {"yes", "no"}. YOUR NETWORK CONFIG HERE, will do NAT for you if you put "yes".

--- a/spgw/Dockerfile
+++ b/spgw/Dockerfile
@@ -215,12 +215,13 @@ RUN make -j`nproc`
 
 RUN mkdir -p /usr/local/etc/oai/freeDiameter
 RUN cp /root/openair-cn/etc/spgw.conf /usr/local/etc/oai/
-RUN sed -i s/"192.168.11.17"/"192.168.142.30"/g /usr/local/etc/oai/spgw.conf
-RUN sed -i s/"eth3"/"eth1"/g /usr/local/etc/oai/spgw.conf
-
-#  PGW_INTERFACE_NAME_FOR_SGI            = "eth3";                         # STRING, YOUR NETWORK CONFIG HERE
-#        PGW_MASQUERADE_SGI                    = "no";                           # STRING, {"yes", "no"}. YOUR NETWORK CONFIG HERE, will do NAT for you if you put "yes".
-#        UE_TCP_MSS_CLAMPING                   = "no";                           # STRING, {"yes", "no"}. 
-
 RUN apt-get -qy install iptables
-ENTRYPOINT bash -x -c "/root/openair-cn/build/spgw/build/spgw"
+
+ENV SGW_IPV4_ADDRESS_FOR_S1U_S12_S4_UP="192.168.142.30"
+ENV PGW_INTERFACE_NAME_FOR_SGI="eth1"
+
+#ready to work
+WORKDIR /root
+COPY start.sh /root/start.sh
+RUN chmod +x /root/start.sh
+ENTRYPOINT "/root/start.sh"

--- a/spgw/spgw.conf
+++ b/spgw/spgw.conf
@@ -1,0 +1,104 @@
+################################################################################
+# Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The OpenAirInterface Software Alliance licenses this file to You under 
+# the Apache License, Version 2.0  (the "License"); you may not use this file
+# except in compliance with the License.  
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+# For more information about the OpenAirInterface (OAI) Software Alliance:
+#      contact@openairinterface.org
+################################################################################
+S-GW : 
+{
+    NETWORK_INTERFACES : 
+    {
+        # S-GW binded interface for S11 communication (GTPV2-C), if none selected the ITTI message interface is used
+        SGW_INTERFACE_NAME_FOR_S11              = "eth0";                         # STRING, interface name, YOUR NETWORK CONFIG HERE
+        SGW_IPV4_ADDRESS_FOR_S11                = "192.168.142.30/24";               # STRING, CIDR, YOUR NETWORK CONFIG HERE
+
+        # S-GW binded interface for S1-U communication (GTPV1-U) can be ethernet interface, virtual ethernet interface, we don't advise wireless interfaces
+        SGW_INTERFACE_NAME_FOR_S1U_S12_S4_UP    = "eth0";                       # STRING, interface name, YOUR NETWORK CONFIG HERE, USE "lo" if S-GW run on eNB host
+        SGW_IPV4_ADDRESS_FOR_S1U_S12_S4_UP      = "192.168.142.30/24";           # STRING, CIDR, YOUR NETWORK CONFIG HERE
+        SGW_IPV4_PORT_FOR_S1U_S12_S4_UP         = 2152;                         # INTEGER, port number, PREFER NOT CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING
+
+        # S-GW binded interface for S5 or S8 communication, not implemented, so leave it to none
+        SGW_INTERFACE_NAME_FOR_S5_S8_UP         = "none";                       # STRING, interface name, DO NOT CHANGE (NOT IMPLEMENTED YET)
+        SGW_IPV4_ADDRESS_FOR_S5_S8_UP           = "0.0.0.0/24";                 # STRING, CIDR, DO NOT CHANGE (NOT IMPLEMENTED YET)
+    };
+    
+    INTERTASK_INTERFACE :
+    {
+        # max queue size per task
+        ITTI_QUEUE_SIZE            = 2000000;                                   # INTEGER
+    };
+
+    LOGGING :
+    {
+        # OUTPUT choice in { "CONSOLE", "SYSLOG", `path to file`", "`IPv4@`:`TCP port num`"} 
+        # `path to file` must start with '.' or '/'
+        # if TCP stream choice, then you can easily dump the traffic on the remote or local host: nc -l `TCP port num` > received.txt
+        OUTPUT            = "CONSOLE";                                          # see 3 lines above 
+        #OUTPUT            = "SYSLOG";                                          # see 4 lines above 
+        #OUTPUT            = "/tmp/spgw.log";                                   # see 5 lines above 
+        #OUTPUT            = "127.0.0.1:5656";                                  # see 6 lines above 
+        
+        # THREAD_SAFE choice in { "yes", "no" } means use of thread safe intermediate buffer then a single thread pick each message log one
+        # by one to flush it to the chosen output
+        THREAD_SAFE       = "no";
+        
+        # COLOR choice in { "yes", "no" } means use of ANSI styling codes or no
+        COLOR              = "yes";
+        
+        # Log level choice in { "EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG", "TRACE"} 
+        UDP_LOG_LEVEL      = "TRACE";
+        GTPV1U_LOG_LEVEL   = "TRACE";
+        GTPV2C_LOG_LEVEL   = "TRACE";
+        SPGW_APP_LOG_LEVEL = "TRACE";
+        S11_LOG_LEVEL      = "TRACE";
+    };
+};
+
+P-GW = 
+{
+    NETWORK_INTERFACES : 
+    {
+        # P-GW binded interface for S5 or S8 communication, not implemented, so leave it to none
+        PGW_INTERFACE_NAME_FOR_S5_S8          = "none";                         # STRING, interface name, DO NOT CHANGE (NOT IMPLEMENTED YET)
+
+        # P-GW binded interface for SGI (egress/ingress internet traffic)
+        PGW_INTERFACE_NAME_FOR_SGI            = "eth0";                         # STRING, YOUR NETWORK CONFIG HERE
+        PGW_MASQUERADE_SGI                    = "yes";                           # STRING, {"yes", "no"}. YOUR NETWORK CONFIG HERE, will do NAT for you if you put "yes".
+        UE_TCP_MSS_CLAMPING                   = "no";                           # STRING, {"yes", "no"}. 
+    };
+    
+    # Pool of UE assigned IP addresses
+    # Do not make IP pools overlap
+    # first IPv4 address X.Y.Z.1 is reserved for GTP network device on SPGW
+    # Normally no more than 16 pools allowed, but since recent GTP kernel module use, only one pool allowed (TODO).
+    IP_ADDRESS_POOL :
+    {
+        IPV4_LIST = (
+                      "172.16.0.0/12"                                           # STRING, CIDR, YOUR NETWORK CONFIG HERE.
+                    );
+    };
+    
+    # DNS address communicated to UEs
+    DEFAULT_DNS_IPV4_ADDRESS     = "8.8.8.8";                                   # YOUR NETWORK CONFIG HERE
+    DEFAULT_DNS_SEC_IPV4_ADDRESS = "8.8.4.4";                                   # YOUR NETWORK CONFIG HERE
+
+    # Non standard feature, normally should be set to "no", but you may need to set to yes for UE that do not explicitly request a PDN address through NAS signalling
+    FORCE_PUSH_PROTOCOL_CONFIGURATION_OPTIONS = "no";                           # STRING, {"yes", "no"}. 
+    UE_MTU                                    = 1500                            # INTEGER
+};
+
+

--- a/spgw/start.sh
+++ b/spgw/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+sed -i s/"192.168.11.17"/"$SGW_IPV4_ADDRESS_FOR_S1U_S12_S4_UP"/g /usr/local/etc/oai/spgw.conf
+sed -i s/"eth3"/"$PGW_INTERFACE_NAME_FOR_SGI"/g /usr/local/etc/oai/spgw.conf
+
+# Start spgw
+sleep 15 && /root/openair-cn/build/spgw/build/spgw


### PR DESCRIPTION
Currently, several parameters are set in the Dockerfile which makes it necessary to rebuild an entire container if one setting changes. (Eg. Rebuild the container if a certificate has to be re-generated.)

By adding `start.sh`, we allow for certain parameters to be passed to the container using environment variables.