### PR TITLE
Add phpmyadmin do the list of services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,16 @@ services:
         - MYSQL_ROOT_PASSWORD=linux
     domainname: openair4G.eur
     hostname: db
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    links:
+     - db:db
+    ports:
+        - 8080:80
+    environment:
+        - MYSQL_ROOT_PASSWORD=linux
+        - MYSQL_USER=root
+        - MYSQL_PASSWORD=linux
   hss:
     build: hss
     links:


### PR DESCRIPTION
Add the [default phpmyadmin](https://hub.docker.com/r/phpmyadmin/phpmyadmin/) to the list of services as an easy way to administer the oai db.

DB information like user and password can be supplied using the docker-compose file. Phpmyadmin can then be used ad `http://localhost:8080`

